### PR TITLE
Add album CoverFlow view

### DIFF
--- a/CoverFlow/AlbumViewModel.swift
+++ b/CoverFlow/AlbumViewModel.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import MusicKit
+
+@MainActor
+class AlbumViewModel: ObservableObject {
+    @Published var albums: [Album] = []
+
+    func requestAuthorization() async {
+        let status = await MusicAuthorization.request()
+        switch status {
+        case .authorized:
+            await loadLibraryAlbums()
+        default:
+            await loadCatalogAlbums()
+        }
+    }
+
+    private func loadLibraryAlbums() async {
+        do {
+            let request = MusicLibraryRequest<Album>()
+            let response = try await request.response()
+            if response.items.isEmpty {
+                await loadCatalogAlbums()
+            } else {
+                albums = response.items
+            }
+        } catch {
+            await loadCatalogAlbums()
+        }
+    }
+
+    private func loadCatalogAlbums() async {
+        do {
+            var search = MusicCatalogSearchRequest(term: "Top Albums", types: [Album.self])
+            search.limit = 30
+            let result = try await search.response()
+            albums = result.albums
+        } catch {
+            print("Failed to load catalog albums: \(error)")
+        }
+    }
+}

--- a/CoverFlow/ContentView.swift
+++ b/CoverFlow/ContentView.swift
@@ -9,13 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        CoverFlowView()
     }
 }
 

--- a/CoverFlow/CoverFlowView.swift
+++ b/CoverFlow/CoverFlowView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import MusicKit
+
+struct CoverFlowView: View {
+    @StateObject private var viewModel = AlbumViewModel()
+    private let itemSize: CGFloat = 220
+
+    var body: some View {
+        GeometryReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 40) {
+                    ForEach(viewModel.albums) { album in
+                        CoverFlowItem(album: album, itemSize: itemSize, containerWidth: proxy.size.width)
+                    }
+                }
+                .padding(.horizontal, (proxy.size.width - itemSize) / 2)
+            }
+            .content.offset(x: 0)
+        }
+        .background(Color.black.ignoresSafeArea())
+        .task {
+            await viewModel.requestAuthorization()
+        }
+    }
+}
+
+struct CoverFlowItem: View {
+    let album: Album
+    let itemSize: CGFloat
+    let containerWidth: CGFloat
+    var body: some View {
+        GeometryReader { geo in
+            let mid = geo.frame(in: .global).midX
+            let screenMid = containerWidth / 2
+            let relative = mid - screenMid
+            let rotation = Angle(degrees: Double(relative / containerWidth) * 50)
+            let scale = max(0.6, 1 - abs(relative) / containerWidth)
+
+            AsyncImage(url: album.artwork?.url(width: Int(itemSize * 2), height: Int(itemSize * 2))) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Color.gray.opacity(0.3)
+            }
+            .frame(width: itemSize, height: itemSize)
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .glassCard()
+            .rotation3DEffect(rotation, axis: (x: 0, y: 1, z: 0))
+            .scaleEffect(scale)
+            .zIndex(Double(scale))
+        }
+        .frame(width: itemSize, height: itemSize)
+    }
+}
+
+#Preview {
+    CoverFlowView()
+}

--- a/CoverFlow/GlassCardModifier.swift
+++ b/CoverFlow/GlassCardModifier.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct GlassCardModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding(8)
+            .background {
+                if #available(iOS 26, *) {
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .fill(.glass)
+                        .glassBackgroundEffect()
+                } else {
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .fill(.thinMaterial)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+}
+
+extension View {
+    func glassCard() -> some View {
+        modifier(GlassCardModifier())
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# CoverFlow
+
+An experimental iOS 26 SwiftUI application that displays a horizontal CoverFlow of Apple Music albums. The app requests access to your Apple Music library on launch and shows album art using a glass style UI.
+
+* Uses `MusicKit` to fetch albums from the user's library with a catalog fallback.
+* Displays album artwork in a swipeable CoverFlow carousel.
+* Applies the latest iOS glass materials for a translucent look.
+* No playback controls or additional chrome — just album covers.
+
+This project is intended as a proof of concept and may require the latest Xcode/iOS SDKs to build.


### PR DESCRIPTION
## Summary
- fetch albums using MusicKit
- show album art in a horizontal CoverFlow carousel
- apply glass styled cards for a translucent look
- document the project

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_685c38252a608324ad68a46fd8f4956c