### PR TITLE
Fix compile errors for older Swift

### DIFF
--- a/CoverFlow/AlbumViewModel.swift
+++ b/CoverFlow/AlbumViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 import MusicKit
 
 @MainActor
@@ -22,7 +23,7 @@ class AlbumViewModel: ObservableObject {
             if response.items.isEmpty {
                 await loadCatalogAlbums()
             } else {
-                albums = response.items
+                albums = Array(response.items)
             }
         } catch {
             await loadCatalogAlbums()
@@ -34,7 +35,7 @@ class AlbumViewModel: ObservableObject {
             var search = MusicCatalogSearchRequest(term: "Top Albums", types: [Album.self])
             search.limit = 30
             let result = try await search.response()
-            albums = result.albums
+            albums = Array(result.albums)
         } catch {
             print("Failed to load catalog albums: \(error)")
         }

--- a/CoverFlow/GlassCardModifier.swift
+++ b/CoverFlow/GlassCardModifier.swift
@@ -5,14 +5,8 @@ struct GlassCardModifier: ViewModifier {
         content
             .padding(8)
             .background {
-                if #available(iOS 26, *) {
-                    RoundedRectangle(cornerRadius: 20, style: .continuous)
-                        .fill(.glass)
-                        .glassBackgroundEffect()
-                } else {
-                    RoundedRectangle(cornerRadius: 20, style: .continuous)
-                        .fill(.thinMaterial)
-                }
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(.thinMaterial)
             }
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
     }


### PR DESCRIPTION
## Summary
- import Combine in `AlbumViewModel`
- convert `MusicItemCollection` results to arrays
- simplify glass card modifier to use `thinMaterial`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c39e4cc9883248915f5059f3bb223