### PR TITLE
Replace MusicKit with placeholder album data

### DIFF
--- a/CoverFlow/Album.swift
+++ b/CoverFlow/Album.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Album: Identifiable {
+    let id = UUID()
+    let artworkURL: URL
+}

--- a/CoverFlow/AlbumViewModel.swift
+++ b/CoverFlow/AlbumViewModel.swift
@@ -1,43 +1,15 @@
 import SwiftUI
-import Combine
-import MusicKit
 
 @MainActor
 class AlbumViewModel: ObservableObject {
     @Published var albums: [Album] = []
 
-    func requestAuthorization() async {
-        let status = await MusicAuthorization.request()
-        switch status {
-        case .authorized:
-            await loadLibraryAlbums()
-        default:
-            await loadCatalogAlbums()
-        }
-    }
-
-    private func loadLibraryAlbums() async {
-        do {
-            let request = MusicLibraryRequest<Album>()
-            let response = try await request.response()
-            if response.items.isEmpty {
-                await loadCatalogAlbums()
-            } else {
-                albums = Array(response.items)
-            }
-        } catch {
-            await loadCatalogAlbums()
-        }
-    }
-
-    private func loadCatalogAlbums() async {
-        do {
-            var search = MusicCatalogSearchRequest(term: "Top Albums", types: [Album.self])
-            search.limit = 30
-            let result = try await search.response()
-            albums = Array(result.albums)
-        } catch {
-            print("Failed to load catalog albums: \(error)")
+    func loadSampleAlbums() {
+        let seeds = 1...20
+        albums = seeds.compactMap { i in
+            URL(string: "https://picsum.photos/seed/\(i)/600")
+        }.map { url in
+            Album(artworkURL: url)
         }
     }
 }

--- a/CoverFlow/CoverFlowView.swift
+++ b/CoverFlow/CoverFlowView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import MusicKit
 
 struct CoverFlowView: View {
     @StateObject private var viewModel = AlbumViewModel()
@@ -19,7 +18,7 @@ struct CoverFlowView: View {
         }
         .background(Color.black.ignoresSafeArea())
         .task {
-            await viewModel.requestAuthorization()
+            viewModel.loadSampleAlbums()
         }
     }
 }
@@ -36,7 +35,7 @@ struct CoverFlowItem: View {
             let rotation = Angle(degrees: Double(relative / containerWidth) * 50)
             let scale = max(0.6, 1 - abs(relative) / containerWidth)
 
-            AsyncImage(url: album.artwork?.url(width: Int(itemSize * 2), height: Int(itemSize * 2))) { image in
+            AsyncImage(url: album.artworkURL) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)


### PR DESCRIPTION
## Summary
- remove MusicKit usage and seed with placeholder cover images
- display each placeholder album in the CoverFlow carousel

## Testing
- `swiftc --version`


------
https://chatgpt.com/codex/tasks/task_e_685c3d1db63883248de06f0c68e34a63